### PR TITLE
Preprocess left and right

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spherical2images"]
-	path = spherical2images
-	url = https://github.com/developmentseed/spherical2images.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spherical2images"]
+	path = spherical2images
+	url = git@github.com:funkyrailroad/spherical2images.git

--- a/pre_processing/pre_processing.sh
+++ b/pre_processing/pre_processing.sh
@@ -23,4 +23,4 @@ $spherical2imagesdocker clip_mapillary_pano \
   --image_clip_size=1024 \
   --output_file_points=${outputDir}/mapillary_points_panoramic_process_new.geojson \
   --output_images_path=${outputDir}/images_new \
-  --cube_sides=front,back
+  --cube_sides=right,left


### PR DESCRIPTION
This modifies spherical2images so the left and right cube_sides actually correspond to left and right sections of the 360 view, for the red cross orientation of the camera. It does appear that sometimes all the directions except for top and bottom are flipped across different sequences, e.g. right is left, left is right, front is back and back is front.

At least specifying right/left will get both right and left cube_faces, although they may be oppositely labeled.